### PR TITLE
Fix various encoding problems in encodeContenthash

### DIFF
--- a/src/utils/contents.js
+++ b/src/utils/contents.js
@@ -43,7 +43,7 @@ export function encodeContenthash(text) {
   let content, contentType
   let encoded = false
   if (!!text) {
-    let matched = text.match(/^(ipfs|bzz|onion):\/\/(.*)/)
+    let matched = text.match(/^(ipfs|bzz|onion|onion3):\/\/(.*)/)
     if (matched) {
       contentType = matched[1]
       content = matched[2]
@@ -51,14 +51,19 @@ export function encodeContenthash(text) {
 
     try {
       if (contentType === 'ipfs') {
-        encoded = '0x' + contentHash.fromIpfs(content)
+        if(content.length >= 4) {
+          encoded = '0x' + contentHash.fromIpfs(content)
+        }
       } else if (contentType === 'bzz') {
-        encoded = '0x' + contentHash.fromSwarm(content)
+        if(content.length >= 4) {
+          encoded = '0x' + contentHash.fromSwarm(content)
+        }
       } else if (contentType === 'onion') {
-        console.log(content.length)
         if(content.length == 16) {
           encoded = '0x' + contentHash.encode('onion', content);  
-        } else if(content.length == 56) {
+        } 
+      } else if (contentType === 'onion3') {
+        if(content.length == 56) {
           encoded = '0x' + contentHash.encode('onion3', content);  
         }
       } else {
@@ -69,7 +74,7 @@ export function encodeContenthash(text) {
       }
     } catch (err) {
       console.warn('Error encoding content hash', { text, encoded })
-      throw 'Error encoding content hash'
+      //throw 'Error encoding content hash'
     }
   }
   return encoded

--- a/src/utils/contents.js
+++ b/src/utils/contents.js
@@ -55,7 +55,12 @@ export function encodeContenthash(text) {
       } else if (contentType === 'bzz') {
         encoded = '0x' + contentHash.fromSwarm(content)
       } else if (contentType === 'onion') {
-        encoded = '0x' + contentHash.encode('onion', content);
+        console.log(content.length)
+        if(content.length == 16) {
+          encoded = '0x' + contentHash.encode('onion', content);  
+        } else if(content.length == 56) {
+          encoded = '0x' + contentHash.encode('onion3', content);  
+        }
       } else {
         console.warn('Unsupported protocol or invalid value', {
           contentType,

--- a/src/utils/contents.test.js
+++ b/src/utils/contents.test.js
@@ -83,29 +83,29 @@ describe('test contenthash utility functions', () => {
 
   test('encodeContentHash returns encoded hash', () => {
     const encodedContentHash = encodeContenthash(
-      'onion://vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd'
+      'onion://p53lf57qovyuvwsc6xnrppyply3vtqm7l6pcobkmyqsiofyeznfu5uqd'
     )
 
     expect(encodedContentHash).toBe(
-      '0xbc03767777367962616c34626437737a6d676e6379727575637067666b7161687a64646933376b7463656f336168376e676d636f706e70797964'
+      '0xbd037035336c663537716f7679757677736336786e72707079706c79337674716d376c3670636f626b6d797173696f6679657a6e667535757164'
     )
   })
 
   test('decodeContentHash returns decoded contenthash', () => {
     const decoded = decodeContenthash(
-      '0xbc03767777367962616c34626437737a6d676e6379727575637067666b7161687a64646933376b7463656f336168376e676d636f706e70797964'
+      '0xbd037035336c663537716f7679757677736336786e72707079706c79337674716d376c3670636f626b6d797173696f6679657a6e667535757164'
     )
 
     expect(decoded.decoded).toBe(
-      'vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd'
+      'p53lf57qovyuvwsc6xnrppyply3vtqm7l6pcobkmyqsiofyeznfu5uqd'
     )
-    expect(decoded.protocolType).toBe('onion')
+    expect(decoded.protocolType).toBe('onion3')
     expect(decoded.error).toBe(undefined)
   })
 
   test('isValidContent returns true for real contenthash', () => {
     const valid = isValidContenthash(
-      '0xbc03767777367962616c34626437737a6d676e6379727575637067666b7161687a64646933376b7463656f336168376e676d636f706e70797964'
+      '0xbd037035336c663537716f7679757677736336786e72707079706c79337674716d376c3670636f626b6d797173696f6679657a6e667535757164'
     )
 
     expect(valid).toBe(true)

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -27,7 +27,7 @@ export function getPlaceholder(recordType, contentType) {
       return 'Enter an Ethereum address'
     case 'content':
       if (contentType === 'contenthash') {
-        return 'Enter a content hash (eg: ipfs://..., bzz://..., onion://)'
+        return 'Enter a content hash (eg: ipfs://..., bzz://..., onion://..., onion3://...,)'
       } else {
         return 'Enter a content'
       }

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -27,7 +27,7 @@ export function getPlaceholder(recordType, contentType) {
       return 'Enter an Ethereum address'
     case 'content':
       if (contentType === 'contenthash') {
-        return 'Enter a content hash (eg: ipfs://..., bzz://..., onion://..., onion3://...,)'
+        return 'Enter a content hash (eg: ipfs://..., bzz://..., onion://..., onion3://...)'
       } else {
         return 'Enter a content'
       }


### PR DESCRIPTION
There are some issues when encoding an onion3 address. Now we matched onion and onion3 addresses separately and we check for them to be the correct length. Furthermore we check that swarm and ipfs addresses have a minimum length. 

Finally I had to remove the error throw (I commented it out) otherwise the error would just crash the app. Probably this is not the best practice...