### PR TITLE
Add customProvider swapping

### DIFF
--- a/src/ens.js
+++ b/src/ens.js
@@ -97,12 +97,12 @@ async function getTestRegistrarContract() {
   }
 }
 
-const getENS = async (ensAddress, skipCache) => {
+const getENS = async ensAddress => {
   const networkId = await getNetworkId()
 
   const hasRegistry = has(contracts[networkId], 'registry')
 
-  if (!ENS || skipCache) {
+  if (!ENS) {
     if (!hasRegistry && !ensAddress) {
       throw new Error(`Unsupported network ${networkId}`)
     } else if (contracts[networkId] && !ensAddress) {

--- a/src/ens.js
+++ b/src/ens.js
@@ -97,12 +97,12 @@ async function getTestRegistrarContract() {
   }
 }
 
-const getENS = async ensAddress => {
+const getENS = async (ensAddress, skipCache) => {
   const networkId = await getNetworkId()
 
   const hasRegistry = has(contracts[networkId], 'registry')
 
-  if (!ENS) {
+  if (!ENS || skipCache) {
     if (!hasRegistry && !ensAddress) {
       throw new Error(`Unsupported network ${networkId}`)
     } else if (contracts[networkId] && !ensAddress) {

--- a/src/ens.js
+++ b/src/ens.js
@@ -27,6 +27,10 @@ var contracts = {
 
 let ENS
 
+const clearENSCache = () => {
+  ENS = undefined
+}
+
 function getNamehash(unsanitizedName) {
   return namehash(unsanitizedName)
 }
@@ -165,5 +169,6 @@ export {
   getResolverContract,
   getDnsRegistrarContract,
   getFifsRegistrarContract,
-  normalize
+  normalize,
+  clearENSCache
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,11 @@ import { getENS } from './ens'
 export async function setupENS({
   customProvider,
   ensAddress,
-  reloadOnAccountsChange
+  reloadOnAccountsChange,
+  skipCache
 } = {}) {
-  await setupWeb3({ customProvider, reloadOnAccountsChange })
-  await getENS(ensAddress)
+  await setupWeb3({ customProvider, reloadOnAccountsChange, skipCache })
+  await getENS(ensAddress, skipCache)
 }
 
 export * from './ens'

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-import { setupWeb3 } from './web3'
-import { getENS } from './ens'
+import { setupWeb3, clearWeb3Cache } from './web3'
+import { getENS, clearENSCache } from './ens'
+import { clearRegistrarCache } from './registrar'
 
 export async function setupENS({
   customProvider,
@@ -8,6 +9,12 @@ export async function setupENS({
 } = {}) {
   await setupWeb3({ customProvider, reloadOnAccountsChange })
   await getENS(ensAddress)
+}
+
+export function clearCache() {
+  clearWeb3Cache()
+  clearENSCache()
+  clearRegistrarCache()
 }
 
 export * from './ens'

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,10 @@ import { getENS } from './ens'
 export async function setupENS({
   customProvider,
   ensAddress,
-  reloadOnAccountsChange,
-  skipCache
+  reloadOnAccountsChange
 } = {}) {
-  await setupWeb3({ customProvider, reloadOnAccountsChange, skipCache })
-  await getENS(ensAddress, skipCache)
+  await setupWeb3({ customProvider, reloadOnAccountsChange })
+  await getENS(ensAddress)
 }
 
 export * from './ens'

--- a/src/registrar.js
+++ b/src/registrar.js
@@ -32,6 +32,15 @@ let permanentRegistrarController
 let migrationLockPeriod
 let gracePeriod
 
+const clearRegistrarCache = () => {
+  ethRegistrar = undefined
+  dnsRegistrar = undefined
+  permanentRegistrar = undefined
+  permanentRegistrarController = undefined
+  migrationLockPeriod = undefined
+  gracePeriod = undefined
+}
+
 const getEthResolver = async () => {
   const ENS = await getENS()
   const resolverAddr = await ENS.resolver(getNamehash('eth'))
@@ -525,5 +534,6 @@ export {
   renew,
   transferRegistrars,
   releaseDeed,
-  submitProof
+  submitProof,
+  clearRegistrarCache
 }

--- a/src/web3.js
+++ b/src/web3.js
@@ -8,9 +8,10 @@ let requested = false
 
 export async function setupWeb3({
   customProvider,
-  reloadOnAccountsChange = false
+  reloadOnAccountsChange = false,
+  skipCache = false
 }) {
-  if (provider) {
+  if (provider && !skipCache) {
     return { provider, signer }
   }
   if (customProvider) {

--- a/src/web3.js
+++ b/src/web3.js
@@ -8,10 +8,9 @@ let requested = false
 
 export async function setupWeb3({
   customProvider,
-  reloadOnAccountsChange = false,
-  skipCache = false
+  reloadOnAccountsChange = false
 }) {
-  if (provider && !skipCache) {
+  if (provider) {
     return { provider, signer }
   }
   if (customProvider) {

--- a/src/web3.js
+++ b/src/web3.js
@@ -6,6 +6,13 @@ let signer
 let readOnly = false
 let requested = false
 
+export const clearWeb3Cache = () => {
+  provider = undefined
+  signer = undefined
+  readOnly = false
+  requested = false
+}
+
 export async function setupWeb3({
   customProvider,
   reloadOnAccountsChange = false

--- a/src/web3.js
+++ b/src/web3.js
@@ -17,11 +17,11 @@ export async function setupWeb3({
     if (typeof customProvider === 'string') {
       // handle raw RPC endpoint URL
       provider = new ethers.providers.JsonRpcProvider(customProvider)
-      signer = provider.getSigner()
     } else {
       // handle EIP 1193 provider
       provider = new ethers.providers.Web3Provider(customProvider)
     }
+    signer = provider.getSigner()
     return { provider, signer }
   }
 


### PR DESCRIPTION
This PR:

- adds creating `signer` when `customProvider` is supplied to `setupWeb3()`
- allows to reset previously set and cached provider (`clearCache()`)
- allows to override previously set and cached provider (`clearCache(); setupENS()`)

All that is needed to be able to switch providers during runtime