### PR TITLE
Fix registration date error

### DIFF
--- a/src/registrar.js
+++ b/src/registrar.js
@@ -23,10 +23,9 @@ import {
   getLegacyProvider
 } from './web3'
 
-import { namehash } from './utils/namehash'
 
 import { interfaces } from './constants/interfaces'
-import { isEncodedLabelhash, labelhash } from './utils/labelhash'
+import { namehash, isEncodedLabelhash, labelhash, getEnsStartBlock } from './utils'
 import { utils } from 'ethers'
 
 const {
@@ -168,6 +167,7 @@ export default class Registrar {
     }
     try {
       const labelHash = labelhash(label)
+      const startBlock = await getEnsStartBlock()
 
       // Returns true if name is available
       if (isEncodedLabelhash(label)) {
@@ -176,17 +176,26 @@ export default class Registrar {
         getAvailable = RegistrarController.available(label)
       }
 
-      const [available, nameExpires, gracePeriod] = await Promise.all([
+      const [available, nameExpires, gracePeriod, block] = await Promise.all([
         getAvailable,
         Registrar.nameExpires(labelHash),
-        this.getGracePeriod(Registrar)
+        this.getGracePeriod(Registrar),
+        this.getRegistrarEvent('NameRegistered', {
+          topics: [labelHash],
+          fromBlock: startBlock
+        }).then(logs => {
+          if (logs.length > 0) {
+            return getBlock(logs[logs.length - 1].blockNumber)
+          }
+        })
       ])
 
       ret = {
         ...ret,
         available,
         gracePeriod,
-        nameExpires: nameExpires > 0 ? new Date(nameExpires * 1000) : null
+        nameExpires: nameExpires > 0 ? new Date(nameExpires * 1000) : null,
+        registrationDate: block && block.timestamp * 1000
       }
       // Returns registrar address if owned by new registrar.
       // Keep it as a separate call as this will throw exception for non existing domains
@@ -232,6 +241,9 @@ export default class Registrar {
           ret.isNewRegistrar = true
           ret.gracePeriodEndDate = gracePeriodEndDate
         }
+      }
+      if (legacyEntry.registrationDate && permEntry.registrationDate) {
+        ret.registrationDate = permEntry.registrationDate
       }
     }
 

--- a/src/registrar.js
+++ b/src/registrar.js
@@ -627,6 +627,23 @@ export default class Registrar {
       return new Date(result * 1000)
     }
   }
+
+  async getRegistrarEvent(event, { topics = [], fromBlock = 0 }) {
+    const provider = await getProvider()
+    const { permanentRegistrar: Registrar } = this
+    let Event = Registrar.filters[event]()
+
+    const filter = {
+      fromBlock,
+      toBlock: 'latest',
+      address: Event.address,
+      topics: [...Event.topics, ...topics]
+    }
+
+    const logs = await provider.getLogs(filter)
+
+    return logs
+  }
 }
 
 async function getEthResolver(ENS) {


### PR DESCRIPTION
Fixes ensdomains/ens-app#1331

This PR:
- Adds method in class Registrar to query events
- Parses NameRegistered events from permanent registrar filtered by selected subdomain
- If subdomain previously registered in legacy auction-based registrar, takes block timestamp of last emitted NameRegistered event as registration date for selected subdomain
 
Before
![image](https://user-images.githubusercontent.com/53792888/141260328-3bc3bb0c-20a5-4cf1-b768-a59de43b67b0.png)
After
![image](https://user-images.githubusercontent.com/53792888/141260379-986eb5fd-5807-440d-a4f6-da62f935cb5f.png)
