### PR TITLE
parseSearchTerm should count code points instead of UTF-16 characters

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -65,7 +65,7 @@ const mergeLabels = (labels1, labels2) =>
 
 function validateName(name) {
   const nameArray = name.split('.')
-  const hasEmptyLabels = nameArray.filter(e => e.length < 1).length > 0
+  const hasEmptyLabels = nameArray.some(label => label.length == 0); 
   if (hasEmptyLabels) throw new Error('Domain cannot have empty labels')
   const normalizedArray = nameArray.map(label => {
     if(label === '[root]'){
@@ -106,7 +106,7 @@ const parseSearchTerm = (term, validTld) => {
     const termArray = term.split('.')
     const tld = term.match(regex) ? term.match(regex)[0] : ''
     if (validTld) {
-      if (tld === 'eth' && termArray[termArray.length - 2].length < 3) {
+      if (tld === 'eth' && [...termArray[termArray.length - 2]].length < 3) { // code-point length
         return 'short'
       }
       return 'supported'


### PR DESCRIPTION
I believe `length(UTF-16) is always >= length(codepoints)` so this change is minor, however the [contract](https://github.com/ensdomains/ethregistrar/blob/master/contracts/ETHRegistrarController.sol#L57-L59) counts [codepoints](https://github.com/ensdomains/ethregistrar/blob/master/contracts/StringUtils.sol#L10).