### PR TITLE
Fix DNSRegistrar Interaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/ui",
-  "version": "3.3.25",
+  "version": "3.3.26",
   "description": "UI components and reusable code",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/registrar.js
+++ b/src/registrar.js
@@ -628,7 +628,9 @@ export default class Registrar {
     const user = await signer.getAddress()
     const registrar = registrarWithoutSigner.connect(signer)
     const proofData = await claim.getProofData()
-    const data = isOld ? proofData.data : proofData.rrsets
+    const data = isOld
+      ? proofData.data
+      : proofData.rrsets.map((x) => Object.values(x))
     const proof = proofData.proof
 
     if (data.length === 0) {


### PR DESCRIPTION
Fixes issue with DNSRegistrar interaction.

Removes names from tuples so ethers doesn't throw an error.

Original Issue:
ensdomains/ens-app#1450
