### PR TITLE
Add ipns domain name encode retry

### DIFF
--- a/src/utils/contents.js
+++ b/src/utils/contents.js
@@ -92,7 +92,12 @@ export function encodeContenthash(text) {
           encoded = '0x' + contentHash.encode('ipfs-ns', content);
         }
       } else if (contentType === 'ipns') {
-        encoded = '0x' + contentHash.encode('ipns-ns', content);
+        try {
+          encoded = '0x' + contentHash.encode('ipns-ns', content);
+        } catch (err) {
+          // if its a domain the above will error out
+          encoded = '0x' + contentHash.encode('ipns-dns', content);
+        }
       } else if (contentType === 'bzz') {
         if(content.length >= 4) {
           encoded = '0x' + contentHash.fromSwarm(content)


### PR DESCRIPTION
As per https://github.com/ensdomains/ens-app/issues/1430 re-add support for domain ipns entries. I saw a couple of comments in the code mentioning deprecation of ipns-ns domain support but wasnt 100% sure so thought Id make the PR anyway.

I needed this functionality for a personal project I was setting up so ran this locally to set my domain. 

This PR goes alongside a PR into content-hash.

https://www.loom.com/share/d7cf8930936d4b7182b5304703a195cc