### PR TITLE
Support passing a BaseProvider as a custom provider

### DIFF
--- a/src/web3.js
+++ b/src/web3.js
@@ -56,6 +56,9 @@ export async function setupWeb3({
         provider = getJsonRpcProvider(customProvider)
       }
       signer = provider.getSigner()
+    } else if (customProvider instanceof ethers.providers.BaseProvider) {
+      provider = customProvider
+      signer = provider.getSigner()
     } else {
       // handle EIP 1193 provider
       provider = getWeb3Provider(customProvider)


### PR DESCRIPTION
I've deployed ENS to a private PoA network that we use for internal testing. To get [ens-app](https://github.com/ensdomains/ens-app) working, I needed to be able to pass a provider with a custom network to this library.

This PR checks if the `customProvider` is a `ethers.providers.BaseProvider`, and if so uses it directly rather than wrapping it.